### PR TITLE
Initial fleshing out of lib

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the official list of the Drone Plugins project authors
+# for copyright purposes.
+
+# Names should be added to this file as
+# Name or Organization
+# Email addresses for individuals are tracked elsewhere to avoid spam.
+
+Don Olmstead

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/drone-plugins/drone-plugin-lib
+
+go 1.13
+
+require github.com/urfave/cli v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/urfave/cli v1.21.0 h1:wYSSj06510qPIzGSua9ZqsncMmWE3Zr55KBERygyrxE=
+github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -13,8 +13,43 @@ package plugin
 // Drone prior to the 1.0 release.
 
 const (
-	// StepNameEnvVar is the environment variable for setting Step.Name.
+	//---------------------------------------------------------------------
+	// Stage Enviornment Variables
+	//---------------------------------------------------------------------
+
+	// StageArchEnvVar corresponds to Stage.Arch.
+	StageArchEnvVar = "DRONE_STAGE_ARCH"
+	// StageDependsOnEnvVar corresponds to Stage.DependsOn.
+	StageDependsOnEnvVar = "DRONE_STAGE_DEPENDS_ON"
+	// StageFinishedEnvVar corresponds to Stage.Finished.
+	StageFinishedEnvVar = "DRONE_STAGE_FINISHED"
+	// StageKindEnvVar corresponds Stage.Kind.
+	StageKindEnvVar = "DRONE_STAGE_KIND"
+	// StageMachineEnvVar corresponds to Stage.Machine.
+	StageMachineEnvVar = "DRONE_STAGE_MACHINE"
+	// StageNameEnvVar corresponds to Stage.Name.
+	StageNameEnvVar = "DRONE_STAGE_NAME"
+	// StageNumberEnvVar corresponds to Stage.Number.
+	StageNumberEnvVar = "DRONE_STAGE_NUMBER"
+	// StageOSEnvVar corresponds to Stage.OS.
+	StageOSEnvVar = "DRONE_STAGE_OS"
+	// StageStartedEnvVar corresponds to Stage.Started.
+	StageStartedEnvVar = "DRONE_STAGE_STARTED"
+	// StageStatusEnvVar corresponds to Stage.Status.
+	StageStatusEnvVar = "DRONE_STAGE_STATUS"
+	// StageTypeEnvVar corresponds to Stage.Type.
+	StageTypeEnvVar = "DRONE_STAGE_TYPE"
+	// StageVariantEnvVar corresponds to Stage.Variant.
+	StageVariantEnvVar = "DRONE_STAGE_VARIANT"
+	// StageVersionEnvVar corresponds to Stage.Version.
+	StageVersionEnvVar = "DRONE_STAGE_VERSION"
+
+	//---------------------------------------------------------------------
+	// Step Environment Variables
+	//---------------------------------------------------------------------
+
+	// StepNameEnvVar corresponds to Step.Name.
 	StepNameEnvVar = "DRONE_STEP_NAME"
-	// StepNumberEnvVar is the environment variable for setting Step.Number.
+	// StepNumberEnvVar corresponds to Step.Number.
 	StepNumberEnvVar = "DRONE_STEP_NUMBER"
 )

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -5,6 +5,13 @@
 
 package plugin
 
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
 // List of enviornment variables set by Drone when running a step within a
 // build stage.
 //
@@ -53,3 +60,84 @@ const (
 	// StepNumberEnvVar corresponds to Step.Number.
 	StepNumberEnvVar = "DRONE_STEP_NUMBER"
 )
+
+// StringEnvVar gets the environment variable's value.
+//
+// If the value is not present then this returns the empty string.
+func StringEnvVar(envVar string) string {
+	return envVarValue(envVar)
+}
+
+// StringSliceEnvVar gets the environment variable as a string slice.
+//
+// If the value is not present then this returns an empty slice.
+func StringSliceEnvVar(envVar string) []string {
+	return strings.Split(envVarValue(envVar), ",")
+}
+
+// IntEnvVar gets the environment variable as an int.
+//
+// If the value is not present then this returns 0.
+func IntEnvVar(envVar string) int {
+	return int(Int64EnvVar(envVar))
+}
+
+// Int64EnvVar gets the environment variable as an int64.
+//
+// If the value is not present then this returns 0.
+func Int64EnvVar(envVar string) int64 {
+	value, err := strconv.ParseInt(envVarValue(envVar), 0, 64)
+
+	if err != nil {
+		return 0
+	}
+
+	return value
+}
+
+// UintEnvVar gets the environment variable as an uint.
+//
+// If the value is not present then this returns 0.
+func UintEnvVar(envVar string) uint {
+	return uint(Uint64EnvVar(envVar))
+}
+
+// Uint64EnvVar gets the environment variable as an uint64.
+//
+// If the value is not present then this returns 0.
+func Uint64EnvVar(envVar string) uint64 {
+	value, err := strconv.ParseUint(envVarValue(envVar), 0, 64)
+
+	if err != nil {
+		return 0
+	}
+
+	return value
+}
+
+// BoolEnvVar gets the environment variable as a bool.
+//
+// If the value is not present then this returns false.
+func BoolEnvVar(envVar string) bool {
+	value, err := strconv.ParseBool(envVarValue(envVar))
+
+	if err != nil {
+		return false
+	}
+
+	return value
+}
+
+// TimeEnvVar gets the environment variable as a Time created from a unix
+// timestamp.
+//
+// If the value is not present then this returns time.Unix(0).
+func TimeEnvVar(envVar string) time.Time {
+	return time.Unix(Int64EnvVar(envVar), 0)
+}
+
+// envVarValue returns the first matched environment variable or the empty
+// string if none was found.
+func envVarValue(envVar string) string {
+	return os.Getenv(envVar)
+}

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -22,6 +22,7 @@ import (
 const (
 	// The following environment variables are being ignored currently
 	//
+	// * DRONE_COMMIT - Redundant with DRONE_COMMIT_SHA
 	// * DRONE_GIT_HTTP_URL
 	// * DRONE_GIT_SSH_URL
 	// * DRONE_REPO_NAMESPACE - Redundant to DRONE_REPO_OWNER
@@ -48,6 +49,33 @@ const (
 	RepoSCMEnvVar = "DRONE_REPO_SCM"
 	// RepoVisibilityEnvVar corresponds to Repo.Visbility.
 	RepoVisibilityEnvVar = "DRONE_REPO_VISIBILITY"
+
+	//---------------------------------------------------------------------
+	// Commit Enviornment Variables
+	//---------------------------------------------------------------------
+
+	// CommitAfterEnvVar corresponds to Commit.After.
+	CommitAfterEnvVar = "DRONE_COMMIT_AFTER"
+	// CommitAuthorEnvVar corresponds to Commit.Author.
+	CommitAuthorEnvVar = "DRONE_COMMIT_AUTHOR"
+	// CommitAuthorAvatarEnvVar corresponds to Commit.AuthorAvatar.
+	CommitAuthorAvatarEnvVar = "DRONE_COMMIT_AUTHOR_AVATAR"
+	// CommitAuthorEmailEnvVar corresponds to Commit.AuthorEmail.
+	CommitAuthorEmailEnvVar = "DRONE_COMMIT_AUTHOR_EMAIL"
+	// CommitAuthorNameEnvVar corresponds to Commit.AuthorName.
+	CommitAuthorNameEnvVar = "DRONE_COMMIT_AUTHOR_NAME"
+	// CommitBeforeEnvVar corresponds to Commit.Before.
+	CommitBeforeEnvVar = "DRONE_COMMIT_BEFORE"
+	// CommitBranchEnvVar corresponds to Commit.Branch.
+	CommitBranchEnvVar = "DRONE_COMMIT_BRANCH"
+	// CommitLinkEnvVar corresponds to Commit.Link.
+	CommitLinkEnvVar = "DRONE_COMMIT_LINK"
+	// CommitMessageEnvVar corresponds to Commit.Message.
+	CommitMessageEnvVar = "DRONE_COMMIT_MESSAGE"
+	// CommitRefEnvVar corresponds to Commit.Ref.
+	CommitRefEnvVar = "DRONE_COMMIT_REF"
+	// CommitSHAEnvVar corresponds to Commit.SHA.
+	CommitSHAEnvVar = "DRONE_COMMIT_SHA"
 
 	//---------------------------------------------------------------------
 	// Stage Enviornment Variables

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -20,6 +20,35 @@ import (
 // Drone prior to the 1.0 release.
 
 const (
+	// The following environment variables are being ignored currently
+	//
+	// * DRONE_GIT_HTTP_URL
+	// * DRONE_GIT_SSH_URL
+	// * DRONE_REPO_NAMESPACE - Redundant to DRONE_REPO_OWNER
+
+	//---------------------------------------------------------------------
+	// Repo Enviornment Variables
+	//---------------------------------------------------------------------
+
+	// RepoDefaultBranchEnvVar corresponds to Repo.DefaultBranch.
+	RepoDefaultBranchEnvVar = "DRONE_REPO_BRANCH"
+	// RepoFullNameEnvVar corresponds to Repo.FullName.
+	RepoFullNameEnvVar = "DRONE_REPO"
+	// RepoLinkEnvVar corresponds to Repo.Link.
+	RepoLinkEnvVar = "DRONE_REPO_LINK"
+	// RepoNameEnvVar corresponds to Repo.Name
+	RepoNameEnvVar = "DRONE_REPO_NAME"
+	// RepoOwnerEnvVar corresponds to Repo.Owner.
+	RepoOwnerEnvVar = "DRONE_REPO_OWNER"
+	// RepoPrivateEnvVar corresponds to Repo.Private.
+	RepoPrivateEnvVar = "DRONE_REPO_PRIVATE"
+	// RepoRemoteURLEnvVar corresponds to Repo.RemoteURL.
+	RepoRemoteURLEnvVar = "DRONE_REMOTE_URL"
+	// RepoSCMEnvVar corresponds to Repo.SCM.
+	RepoSCMEnvVar = "DRONE_REPO_SCM"
+	// RepoVisibilityEnvVar corresponds to Repo.Visbility.
+	RepoVisibilityEnvVar = "DRONE_REPO_VISIBILITY"
+
 	//---------------------------------------------------------------------
 	// Stage Enviornment Variables
 	//---------------------------------------------------------------------

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -35,26 +35,26 @@ const (
 	BuildActionEnvVar = "DRONE_BUILD_ACTION"
 	// BuildCreatedEnvVar corresponds to Build.Created.
 	BuildCreatedEnvVar = "DRONE_BUILD_CREATED"
+	// BuildDeployToEnvVar corresponds to Build.DeployTo.
+	BuildDeployToEnvVar = "DRONE_DEPLOY_TO"
 	// BuildEventEnvVar corresponds to Build.Event.
 	BuildEventEnvVar = "DRONE_BUILD_EVENT"
+	// BuildFailedStagesEnvVar corresponds to Build.FailedStages.
+	BuildFailedStagesEnvVar = "DRONE_FAILED_STAGES"
+	// BuildFailedStepsEnvVar corresponds to Build.FailedSteps.
+	BuildFailedStepsEnvVar = "DRONE_FAILED_STEPS"
 	// BuildFinishedEnvVar corresponds to Build.Finished.
 	BuildFinishedEnvVar = "DRONE_BUILD_FINISHED"
 	// BuildNumberEnvVar corresponds to Build.Created.
 	BuildNumberEnvVar = "DRONE_BUILD_NUMBER"
 	// BuildParentEnvVar corresponds to Build.Parent.
 	BuildParentEnvVar = "DRONE_BUILD_PARENT"
+	// BuildPullRequestEnvVar corresponds to Build.PullRequest.
+	BuildPullRequestEnvVar = "DRONE_PULL_REQUEST"
 	// BuildStartedEnvVar corresponds to Build.Started.
 	BuildStartedEnvVar = "DRONE_BUILD_STARTED"
 	// BuildStatusEnvVar corresponds to Build.Status.
 	BuildStatusEnvVar = "DRONE_BUILD_STATUS"
-	// BuildDeployToEnvVar corresponds to Build.DeployTo.
-	BuildDeployToEnvVar = "DRONE_DEPLOY_TO"
-	// BuildFailedStagesEnvVar corresponds to Build.FailedStages.
-	BuildFailedStagesEnvVar = "DRONE_FAILED_STAGES"
-	// BuildFailedStepsEnvVar corresponds to Build.FailedSteps.
-	BuildFailedStepsEnvVar = "DRONE_FAILED_STEPS"
-	// BuildPullRequestEnvVar corresponds to Build.PullRequest.
-	BuildPullRequestEnvVar = "DRONE_PULL_REQUEST"
 	// BuildSourceBranchEnvVar corresponds to Build.SourceBranch.
 	BuildSourceBranchEnvVar = "DRONE_SOURCE_BRANCH"
 	// BuildTagEnvVar corresponds to Build.Tag.

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -88,6 +88,27 @@ const (
 	StepNameEnvVar = "DRONE_STEP_NAME"
 	// StepNumberEnvVar corresponds to Step.Number.
 	StepNumberEnvVar = "DRONE_STEP_NUMBER"
+
+	//---------------------------------------------------------------------
+	// SemVer Variables
+	//---------------------------------------------------------------------
+
+	// SemVerBuildEnvVar corresponds to SemVer.Build.
+	SemVerBuildEnvVar = "DRONE_SEMVER_BUILD"
+	// SemVerErrorEnvVar corresponds to SemVer.Error.
+	SemVerErrorEnvVar = "DRONE_SEMVER_ERROR"
+	// SemVerMajorEnvVar corresponds to SemVer.Major.
+	SemVerMajorEnvVar = "DRONE_SEMVER_MAJOR"
+	// SemVerMinorEnvVar corresponds to SemVer.Minor.
+	SemVerMinorEnvVar = "DRONE_SEMVER_MINOR"
+	// SemVerPatchEnvVar corresponds to SemVer.Patch.
+	SemVerPatchEnvVar = "DRONE_SEMVER_PATCH"
+	// SemVerPrereleaseEnvVar corresponds to SemVer.Prerelease
+	SemVerPrereleaseEnvVar = "DRONE_SEMVER_PRERELEASE"
+	// SemVerShortEnvVar corresponds to SemVer.Short.
+	SemVerShortEnvVar = "DRONE_SEMVER_SHORT"
+	// SemVerVersionEnvVar corresponds to SemVer.Version
+	SemVerVersionEnvVar = "DRONE_SEMVER"
 )
 
 // StringEnvVar gets the environment variable's value.

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2019, the Drone Plugins project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license that can be
+// found in the LICENSE file.
+
+package plugin
+
+// List of enviornment variables set by Drone when running a step within a
+// build stage.
+//
+// Multiple values are specified with `,` within the string. If there are
+// multiple values this is to support backward compatibility with versions of
+// Drone prior to the 1.0 release.
+
+const (
+	// StepNameEnvVar is the environment variable for setting Step.Name.
+	StepNameEnvVar = "DRONE_STEP_NAME"
+	// StepNumberEnvVar is the environment variable for setting Step.Number.
+	StepNumberEnvVar = "DRONE_STEP_NUMBER"
+)

--- a/pkg/plugin/env.go
+++ b/pkg/plugin/env.go
@@ -28,6 +28,41 @@ const (
 	// * DRONE_REPO_NAMESPACE - Redundant to DRONE_REPO_OWNER
 
 	//---------------------------------------------------------------------
+	// Build Enviornment Variables
+	//---------------------------------------------------------------------
+
+	// BuildActionEnvVar corresponds to Build.Action.
+	BuildActionEnvVar = "DRONE_BUILD_ACTION"
+	// BuildCreatedEnvVar corresponds to Build.Created.
+	BuildCreatedEnvVar = "DRONE_BUILD_CREATED"
+	// BuildEventEnvVar corresponds to Build.Event.
+	BuildEventEnvVar = "DRONE_BUILD_EVENT"
+	// BuildFinishedEnvVar corresponds to Build.Finished.
+	BuildFinishedEnvVar = "DRONE_BUILD_FINISHED"
+	// BuildNumberEnvVar corresponds to Build.Created.
+	BuildNumberEnvVar = "DRONE_BUILD_NUMBER"
+	// BuildParentEnvVar corresponds to Build.Parent.
+	BuildParentEnvVar = "DRONE_BUILD_PARENT"
+	// BuildStartedEnvVar corresponds to Build.Started.
+	BuildStartedEnvVar = "DRONE_BUILD_STARTED"
+	// BuildStatusEnvVar corresponds to Build.Status.
+	BuildStatusEnvVar = "DRONE_BUILD_STATUS"
+	// BuildDeployToEnvVar corresponds to Build.DeployTo.
+	BuildDeployToEnvVar = "DRONE_DEPLOY_TO"
+	// BuildFailedStagesEnvVar corresponds to Build.FailedStages.
+	BuildFailedStagesEnvVar = "DRONE_FAILED_STAGES"
+	// BuildFailedStepsEnvVar corresponds to Build.FailedSteps.
+	BuildFailedStepsEnvVar = "DRONE_FAILED_STEPS"
+	// BuildPullRequestEnvVar corresponds to Build.PullRequest.
+	BuildPullRequestEnvVar = "DRONE_PULL_REQUEST"
+	// BuildSourceBranchEnvVar corresponds to Build.SourceBranch.
+	BuildSourceBranchEnvVar = "DRONE_SOURCE_BRANCH"
+	// BuildTagEnvVar corresponds to Build.Tag.
+	BuildTagEnvVar = "DRONE_TAG"
+	// BuildTargetBranchEnvVar corresponds to Build.TargetBranch.
+	BuildTargetBranchEnvVar = "DRONE_TARGET_BRANCH"
+
+	//---------------------------------------------------------------------
 	// Repo Enviornment Variables
 	//---------------------------------------------------------------------
 

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -87,3 +87,30 @@ type (
 		Number int
 	}
 )
+
+// StageFromEnv creates a Stage from the environment variables used by Drone.
+func StageFromEnv() Stage {
+	return Stage{
+		Arch:      StringEnvVar(StageArchEnvVar),
+		DependsOn: StringSliceEnvVar(StageDependsOnEnvVar),
+		Finished:  TimeEnvVar(StageFinishedEnvVar),
+		Kind:      StringEnvVar(StageKindEnvVar),
+		Machine:   StringEnvVar(StageMachineEnvVar),
+		Name:      StringEnvVar(StageNameEnvVar),
+		Number:    IntEnvVar(StageNumberEnvVar),
+		OS:        StringEnvVar(StageOSEnvVar),
+		Started:   TimeEnvVar(StageStartedEnvVar),
+		Status:    StringEnvVar(StageStatusEnvVar),
+		Type:      StringEnvVar(StageTypeEnvVar),
+		Variant:   StringEnvVar(StageVariantEnvVar),
+		Version:   StringEnvVar(StageVersionEnvVar),
+	}
+}
+
+// StepFromEnv creates a Step from the environment variables used by Drone.
+func StepFromEnv() Step {
+	return Step{
+		Name:   StringEnvVar(StepNameEnvVar),
+		Number: IntEnvVar(StepNumberEnvVar),
+	}
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -40,6 +40,33 @@ type (
 		Visibility    string
 	}
 
+	// Commit represents the current commit being built.
+	Commit struct {
+		// After contains the commit sha after the patch is applied.
+		After string
+		// Author of the commit.
+		Author string
+		// AuthorAvatar of the commit.
+		AuthorAvatar string
+		// AuthorEmail of the commit.
+		AuthorEmail string
+		// AuthorName of the commit.
+		AuthorName string
+		// Before contains the commit sha before the patch is applied.
+		Before string
+		// Branch target for the push or pull request. This may be empty for
+		// tag events.
+		Branch string
+		// Link to the commit or object in the source control management system.
+		Link string
+		// Message for the current commit.
+		Message string
+		// Ref for the current commit.
+		Ref string
+		// SHA for the current commit.
+		SHA string
+	}
+
 	// Stage represents a build stage.
 	Stage struct {
 		// Arch is the platform architecture of the current build stage.
@@ -139,6 +166,23 @@ func RepoFromEnv() Repo {
 		RemoteURL:     StringEnvVar(RepoRemoteURLEnvVar),
 		SCM:           StringEnvVar(RepoSCMEnvVar),
 		Visibility:    StringEnvVar(RepoVisibilityEnvVar),
+	}
+}
+
+// CommitFromEnv creates a Commit from the environment variables used by Drone.
+func CommitFromEnv() Commit {
+	return Commit{
+		After:        StringEnvVar(CommitAfterEnvVar),
+		Author:       StringEnvVar(CommitAuthorEnvVar),
+		AuthorAvatar: StringEnvVar(CommitAuthorAvatarEnvVar),
+		AuthorEmail:  StringEnvVar(CommitAuthorEmailEnvVar),
+		AuthorName:   StringEnvVar(CommitAuthorNameEnvVar),
+		Before:       StringEnvVar(CommitBeforeEnvVar),
+		Branch:       StringEnvVar(CommitBranchEnvVar),
+		Link:         StringEnvVar(CommitLinkEnvVar),
+		Message:      StringEnvVar(CommitMessageEnvVar),
+		Ref:          StringEnvVar(CommitRefEnvVar),
+		SHA:          StringEnvVar(CommitSHAEnvVar),
 	}
 }
 

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -8,6 +8,25 @@ package plugin
 import "time"
 
 type (
+	// BaseConfig is the common configuration for a plugin.
+	//
+	// The configuration organizes all the information available to a plugin
+	// executing as a step within a stage.
+	//
+	// Plugins can choose to compose this within their own config.
+	//
+	//     import "github.com/drone-plugins/drone-plugin-lib/pkg/plugin"
+	//
+	//     type MyPluginConfig struct {
+	//         plugin.BaseConfig
+	//         Foo string
+	//         Bar string
+	//     }
+	BaseConfig struct {
+		Stage Stage
+		Step  Step
+	}
+
 	// Stage represents a build stage.
 	Stage struct {
 		// Arch is the platform architecture of the current build stage.

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -27,6 +27,19 @@ type (
 		Step  Step
 	}
 
+	// Repo represents the repository for the build.
+	Repo struct {
+		DefaultBranch string
+		FullName      string
+		Link          string
+		Name          string
+		Owner         string
+		Private       bool
+		RemoteURL     string
+		SCM           string
+		Visibility    string
+	}
+
 	// Stage represents a build stage.
 	Stage struct {
 		// Arch is the platform architecture of the current build stage.
@@ -87,6 +100,21 @@ type (
 		Number int
 	}
 )
+
+// RepoFromEnv creates a Repo from the environment variables used by Drone.
+func RepoFromEnv() Repo {
+	return Repo{
+		DefaultBranch: StringEnvVar(RepoDefaultBranchEnvVar),
+		FullName:      StringEnvVar(RepoFullNameEnvVar),
+		Link:          StringEnvVar(RepoLinkEnvVar),
+		Name:          StringEnvVar(RepoNameEnvVar),
+		Owner:         StringEnvVar(RepoOwnerEnvVar),
+		Private:       BoolEnvVar(RepoPrivateEnvVar),
+		RemoteURL:     StringEnvVar(RepoRemoteURLEnvVar),
+		SCM:           StringEnvVar(RepoSCMEnvVar),
+		Visibility:    StringEnvVar(RepoVisibilityEnvVar),
+	}
+}
 
 // StageFromEnv creates a Stage from the environment variables used by Drone.
 func StageFromEnv() Stage {

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -8,29 +8,6 @@ package plugin
 import "time"
 
 type (
-	// Context contains information about the current execution context.
-	//
-	// The context organizes all the information available to a plugin executing
-	// as a step within a stage.
-	//
-	// Plugins can choose to compose this within their own config.
-	//
-	//     import "github.com/drone-plugins/drone-plugin-lib/pkg/plugin"
-	//
-	//     type MyPluginContext struct {
-	//         plugin.Context
-	//         Foo string
-	//         Bar string
-	//     }
-	Context struct {
-		Build  Build
-		Repo   Repo
-		Commit Commit
-		Stage  Stage
-		Step   Step
-		SemVer SemVer
-	}
-
 	// Build represents a build of a repository.
 	Build struct {
 		// Action that triggered the build. This value is used to differentiate

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -110,52 +110,40 @@ type (
 	Stage struct {
 		// Arch is the platform architecture of the current build stage.
 		Arch string
-
 		// DependsOn is a list of dependencies for the current build stage.
 		DependsOn []string
-
 		// Finished is the unix timestamp for when the pipeline is finished.
 		//
 		// A running pipleine cannot have a finish timestamp, therefore, the
 		// system aways sets this value to the current timestamp.
 		Finished time.Time
-
 		// Kind is the kind of resource being executed.
 		//
 		// This value is sourced from the `kind` attribute in the yaml
 		// configuration file
 		Kind string
-
 		// Machine provides the name of the host machine on which the build
 		// stage is currently running.
 		Machine string
-
 		// Name is the name for the current running build stage.
 		Name string
-
 		// Number is the stage number for the current running build stage.
 		Number int
-
 		// OS is the target operating system for the current build stage.
 		OS string
-
 		// Started is the unix timestamp for when a build stage was started by
 		// the runner.
 		Started time.Time
-
 		// Status is the status for the current running build stage.
 		//
 		// If all of the stage's steps are passing, the status defaults to
 		// success.
 		Status string
-
 		// Type is the type of resource being executed.
 		Type string
-
 		// Variant is the target architecture variant for the current build
 		// stage.
 		Variant string
-
 		// Version is OS version for the current build stage.
 		Version string
 	}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, the Drone Plugins project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license that can be
+// found in the LICENSE file.
+
+package plugin
+
+type (
+	// Step represents the currently running step within the stage.
+	Step struct {
+		Name   string
+		Number int
+	}
+)

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -27,6 +27,41 @@ type (
 		Step  Step
 	}
 
+	// Build represents a build of a repository.
+	Build struct {
+		// Action that triggered the build. This value is used to differentiate
+		// bettween a pull request being opened vs synchronized.
+		Action string
+		// Created time of the build.
+		Created time.Time
+		// Event that triggered the build.
+		Event string
+		// Finished time of the build.
+		Finished time.Time
+		// Number for the build.
+		Number int
+		// Parent build number for the build.
+		Parent int
+		// Started time of the build.
+		Started time.Time
+		// Status of the build.
+		Status string
+		// DeployTo the environment.
+		DeployTo string
+		// FailedStages of the build.
+		FailedStages []string
+		// FailedSteps of the build.
+		FailedSteps []string
+		// PullRequest number of the build.
+		PullRequest int
+		// SourceBranch for the pull request.
+		SourceBranch string
+		// Tag of the build.
+		Tag string
+		// TargetBranch for the pull request.
+		TargetBranch string
+	}
+
 	// Repo represents the repository for the build.
 	Repo struct {
 		DefaultBranch string
@@ -153,6 +188,27 @@ type (
 		Version string
 	}
 )
+
+// BuildFromEnv creates a Build from the environment variables used by Drone.
+func BuildFromEnv() Build {
+	return Build{
+		Action:       StringEnvVar(BuildActionEnvVar),
+		Created:      TimeEnvVar(BuildCreatedEnvVar),
+		Event:        StringEnvVar(BuildEventEnvVar),
+		Finished:     TimeEnvVar(BuildFinishedEnvVar),
+		Number:       IntEnvVar(BuildNumberEnvVar),
+		Parent:       IntEnvVar(BuildParentEnvVar),
+		Started:      TimeEnvVar(BuildStartedEnvVar),
+		Status:       StringEnvVar(BuildStatusEnvVar),
+		DeployTo:     StringEnvVar(BuildDeployToEnvVar),
+		FailedStages: StringSliceEnvVar(BuildFailedStagesEnvVar),
+		FailedSteps:  StringSliceEnvVar(BuildFailedStepsEnvVar),
+		PullRequest:  IntEnvVar(BuildPullRequestEnvVar),
+		SourceBranch: StringEnvVar(BuildSourceBranchEnvVar),
+		Tag:          StringEnvVar(BuildTagEnvVar),
+		TargetBranch: StringEnvVar(BuildTargetBranchEnvVar),
+	}
+}
 
 // RepoFromEnv creates a Repo from the environment variables used by Drone.
 func RepoFromEnv() Repo {

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -5,7 +5,63 @@
 
 package plugin
 
+import "time"
+
 type (
+	// Stage represents a build stage.
+	Stage struct {
+		// Arch is the platform architecture of the current build stage.
+		Arch string
+
+		// DependsOn is a list of dependencies for the current build stage.
+		DependsOn []string
+
+		// Finished is the unix timestamp for when the pipeline is finished.
+		//
+		// A running pipleine cannot have a finish timestamp, therefore, the
+		// system aways sets this value to the current timestamp.
+		Finished time.Time
+
+		// Kind is the kind of resource being executed.
+		//
+		// This value is sourced from the `kind` attribute in the yaml
+		// configuration file
+		Kind string
+
+		// Machine provides the name of the host machine on which the build
+		// stage is currently running.
+		Machine string
+
+		// Name is the name for the current running build stage.
+		Name string
+
+		// Number is the stage number for the current running build stage.
+		Number int
+
+		// OS is the target operating system for the current build stage.
+		OS string
+
+		// Started is the unix timestamp for when a build stage was started by
+		// the runner.
+		Started time.Time
+
+		// Status is the status for the current running build stage.
+		//
+		// If all of the stage's steps are passing, the status defaults to
+		// success.
+		Status string
+
+		// Type is the type of resource being executed.
+		Type string
+
+		// Variant is the target architecture variant for the current build
+		// stage.
+		Variant string
+
+		// Version is OS version for the current build stage.
+		Version string
+	}
+
 	// Step represents the currently running step within the stage.
 	Step struct {
 		Name   string

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -34,26 +34,26 @@ type (
 		Action string
 		// Created time of the build.
 		Created time.Time
+		// DeployTo the environment.
+		DeployTo string
 		// Event that triggered the build.
 		Event string
+		// FailedStages of the build.
+		FailedStages []string
+		// FailedSteps of the build.
+		FailedSteps []string
 		// Finished time of the build.
 		Finished time.Time
 		// Number for the build.
 		Number int
 		// Parent build number for the build.
 		Parent int
+		// PullRequest number of the build.
+		PullRequest int
 		// Started time of the build.
 		Started time.Time
 		// Status of the build.
 		Status string
-		// DeployTo the environment.
-		DeployTo string
-		// FailedStages of the build.
-		FailedStages []string
-		// FailedSteps of the build.
-		FailedSteps []string
-		// PullRequest number of the build.
-		PullRequest int
 		// SourceBranch for the pull request.
 		SourceBranch string
 		// Tag of the build.
@@ -194,17 +194,17 @@ func BuildFromEnv() Build {
 	return Build{
 		Action:       StringEnvVar(BuildActionEnvVar),
 		Created:      TimeEnvVar(BuildCreatedEnvVar),
+		DeployTo:     StringEnvVar(BuildDeployToEnvVar),
 		Event:        StringEnvVar(BuildEventEnvVar),
+		FailedStages: StringSliceEnvVar(BuildFailedStagesEnvVar),
+		FailedSteps:  StringSliceEnvVar(BuildFailedStepsEnvVar),
 		Finished:     TimeEnvVar(BuildFinishedEnvVar),
 		Number:       IntEnvVar(BuildNumberEnvVar),
 		Parent:       IntEnvVar(BuildParentEnvVar),
-		Started:      TimeEnvVar(BuildStartedEnvVar),
-		Status:       StringEnvVar(BuildStatusEnvVar),
-		DeployTo:     StringEnvVar(BuildDeployToEnvVar),
-		FailedStages: StringSliceEnvVar(BuildFailedStagesEnvVar),
-		FailedSteps:  StringSliceEnvVar(BuildFailedStepsEnvVar),
 		PullRequest:  IntEnvVar(BuildPullRequestEnvVar),
 		SourceBranch: StringEnvVar(BuildSourceBranchEnvVar),
+		Started:      TimeEnvVar(BuildStartedEnvVar),
+		Status:       StringEnvVar(BuildStatusEnvVar),
 		Tag:          StringEnvVar(BuildTagEnvVar),
 		TargetBranch: StringEnvVar(BuildTargetBranchEnvVar),
 	}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -8,23 +8,27 @@ package plugin
 import "time"
 
 type (
-	// BaseConfig is the common configuration for a plugin.
+	// Context contains information about the current execution context.
 	//
-	// The configuration organizes all the information available to a plugin
-	// executing as a step within a stage.
+	// The context organizes all the information available to a plugin executing
+	// as a step within a stage.
 	//
 	// Plugins can choose to compose this within their own config.
 	//
 	//     import "github.com/drone-plugins/drone-plugin-lib/pkg/plugin"
 	//
-	//     type MyPluginConfig struct {
-	//         plugin.BaseConfig
+	//     type MyPluginContext struct {
+	//         plugin.Context
 	//         Foo string
 	//         Bar string
 	//     }
-	BaseConfig struct {
-		Stage Stage
-		Step  Step
+	Context struct {
+		Build  Build
+		Repo   Repo
+		Commit Commit
+		Stage  Stage
+		Step   Step
+		SemVer SemVer
 	}
 
 	// Build represents a build of a repository.

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -99,6 +99,32 @@ type (
 		Name   string
 		Number int
 	}
+
+	// SemVer represents the semantic version of the currently running build.
+	//
+	// This value is only applicable for tags. If the tag cannot be parsed into
+	// a semantic version then SemVer.Error will have the reason.
+	SemVer struct {
+		// Build version number.
+		//
+		// This is signified by a + at the end of the tag.
+		Build string
+		// Error is the semantic version parsing error if the tag was invalid.
+		Error string
+		// Major version number.
+		Major string
+		// Minor version number.
+		Minor string
+		// Patch version number.
+		Patch string
+		// Prerelease version.
+		Prerelease string
+		// Short version of the semantic version string where labels and
+		// metadata are truncated.
+		Short string
+		// Version is the full semantic version.
+		Version string
+	}
 )
 
 // RepoFromEnv creates a Repo from the environment variables used by Drone.
@@ -140,5 +166,19 @@ func StepFromEnv() Step {
 	return Step{
 		Name:   StringEnvVar(StepNameEnvVar),
 		Number: IntEnvVar(StepNumberEnvVar),
+	}
+}
+
+// SemVerFromEnv creates a SemVer from the environment variables used by Drone.
+func SemVerFromEnv() SemVer {
+	return SemVer{
+		Build:      StringEnvVar(SemVerBuildEnvVar),
+		Error:      StringEnvVar(SemVerErrorEnvVar),
+		Major:      StringEnvVar(SemVerMajorEnvVar),
+		Minor:      StringEnvVar(SemVerMinorEnvVar),
+		Patch:      StringEnvVar(SemVerPatchEnvVar),
+		Prerelease: StringEnvVar(SemVerPrereleaseEnvVar),
+		Short:      StringEnvVar(SemVerShortEnvVar),
+		Version:    StringEnvVar(SemVerVersionEnvVar),
 	}
 }

--- a/pkg/urfave/types.go
+++ b/pkg/urfave/types.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, the Drone Plugins project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license that can be
+// found in the LICENSE file.
+
+package urfave
+
+import "github.com/urfave/cli"
+
+//---------------------------------------------------------------------
+// Transport Flags
+//---------------------------------------------------------------------
+
+// Transport contains options for the underlying http client.
+type Transport struct {
+	// SSLVerify certificate information.
+	SSLVerify bool
+}
+
+const transportSSLVerifyFlag = "transport.ssl-verify"
+
+// TransportFlags has the cli.Flags for the Transport.
+func TransportFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:   transportSSLVerifyFlag,
+			Usage:  "transport ssl verify",
+			EnvVar: "PLUGIN_SSL_VERIFY",
+			Hidden: true,
+		},
+	}
+}
+
+// TransportFromContext creates a Transport from the cli.Context.
+func TransportFromContext(ctx cli.Context) Transport {
+	return Transport{
+		SSLVerify: ctx.Bool(transportSSLVerifyFlag),
+	}
+}

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -137,6 +137,124 @@ func RepoFromContext(ctx *cli.Context) plugin.Repo {
 }
 
 //---------------------------------------------------------------------
+// Commit Flags
+//---------------------------------------------------------------------
+
+const (
+	// CommitAfterFlag corresponds to plugin.Commit.After.
+	CommitAfterFlag = "commit.after"
+	// CommitAuthorFlag corresponds to plugin.Commit.Author.
+	CommitAuthorFlag = "commit.author"
+	// CommitAuthorAvatarFlag corresponds to plugin.Commit.AuthorAvatar.
+	CommitAuthorAvatarFlag = "commit.author-avatar"
+	// CommitAuthorEmailFlag corresponds to plugin.Commit.AuthorEmail.
+	CommitAuthorEmailFlag = "commit.author-email"
+	// CommitAuthorNameFlag corresponds to plugin.Commit.AuthorName.
+	CommitAuthorNameFlag = "commit.author-name"
+	// CommitBeforeFlag corresponds to plugin.Commit.Before.
+	CommitBeforeFlag = "commit.before"
+	// CommitBranchFlag corresponds to plugin.Commit.Branch.
+	CommitBranchFlag = "commit.branch"
+	// CommitLinkFlag corresponds to plugin.Commit.Link.
+	CommitLinkFlag = "commit.link"
+	// CommitMessageFlag corresponds to plugin.Commit.Message.
+	CommitMessageFlag = "commit.message"
+	// CommitRefFlag corresponds to plugin.Commit.Ref.
+	CommitRefFlag = "commit.ref"
+	// CommitSHAFlag corresponds to plugin.Commit.SHA.
+	CommitSHAFlag = "commit.sha"
+)
+
+// CommitFlags has the cli.Flags for the plugin.Commit.
+func CommitFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   CommitAfterFlag,
+			Usage:  "commit after",
+			EnvVar: plugin.CommitAfterEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitAuthorFlag,
+			Usage:  "commit author",
+			EnvVar: plugin.CommitAuthorEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitAuthorAvatarFlag,
+			Usage:  "commit author avatar",
+			EnvVar: plugin.CommitAuthorAvatarEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitAuthorEmailFlag,
+			Usage:  "commit author email",
+			EnvVar: plugin.CommitAuthorEmailEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitAuthorNameFlag,
+			Usage:  "commit author name",
+			EnvVar: plugin.CommitAuthorNameEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitBeforeFlag,
+			Usage:  "commit before",
+			EnvVar: plugin.CommitBeforeEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitBranchFlag,
+			Usage:  "commit branch",
+			EnvVar: plugin.CommitBranchEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitLinkFlag,
+			Usage:  "commit link",
+			EnvVar: plugin.CommitLinkEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitMessageFlag,
+			Usage:  "commit message",
+			EnvVar: plugin.CommitMessageEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitRefFlag,
+			Usage:  "commit ref",
+			EnvVar: plugin.CommitRefEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   CommitSHAFlag,
+			Usage:  "commit sha",
+			EnvVar: plugin.CommitSHAEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// CommitFromContext creates a plugin.Commit from the cli.Context.
+func CommitFromContext(ctx *cli.Context) plugin.Commit {
+	return plugin.Commit{
+		After:        ctx.String(CommitAfterFlag),
+		Author:       ctx.String(CommitAuthorFlag),
+		AuthorAvatar: ctx.String(CommitAuthorAvatarFlag),
+		AuthorEmail:  ctx.String(CommitAuthorEmailFlag),
+		AuthorName:   ctx.String(CommitAuthorNameFlag),
+		Before:       ctx.String(CommitBeforeFlag),
+		Branch:       ctx.String(CommitBranchFlag),
+		Link:         ctx.String(CommitLinkFlag),
+		Message:      ctx.String(CommitMessageFlag),
+		Ref:          ctx.String(CommitRefFlag),
+		SHA:          ctx.String(CommitSHAFlag),
+	}
+}
+
+//---------------------------------------------------------------------
 // Stage Flags
 //---------------------------------------------------------------------
 

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -30,18 +30,146 @@
 package urfave
 
 import (
+	"time"
+
 	"github.com/drone-plugins/drone-plugin-lib/pkg/plugin"
 	"github.com/urfave/cli"
 )
+
+//---------------------------------------------------------------------
+// Stage Flags
+//---------------------------------------------------------------------
+
+const (
+	// StageArchFlag corresponds to plugin.Stage.Arch.
+	StageArchFlag = "DRONE_STAGE_ARCH"
+	// StageDependsOnFlag corresponds to plugin.Stage.DependsOn.
+	StageDependsOnFlag = "DRONE_STAGE_DEPENDS_ON"
+	// StageFinishedFlag corresponds to plugin.Stage.Finished.
+	StageFinishedFlag = "DRONE_STAGE_FINISHED"
+	// StageKindFlag corresponds Stage.Kind.
+	StageKindFlag = "DRONE_STAGE_KIND"
+	// StageMachineFlag corresponds to plugin.Stage.Machine.
+	StageMachineFlag = "DRONE_STAGE_MACHINE"
+	// StageNameFlag corresponds to plugin.Stage.Name.
+	StageNameFlag = "DRONE_STAGE_NAME"
+	// StageNumberFlag corresponds to plugin.Stage.Number.
+	StageNumberFlag = "DRONE_STAGE_NUMBER"
+	// StageOSFlag corresponds to plugin.Stage.OS.
+	StageOSFlag = "DRONE_STAGE_OS"
+	// StageStartedFlag corresponds to plugin.Stage.Started.
+	StageStartedFlag = "DRONE_STAGE_STARTED"
+	// StageStatusFlag corresponds to plugin.Stage.Status.
+	StageStatusFlag = "DRONE_STAGE_STATUS"
+	// StageTypeFlag corresponds to plugin.Stage.Type.
+	StageTypeFlag = "DRONE_STAGE_TYPE"
+	// StageVariantFlag corresponds to plugin.Stage.Variant.
+	StageVariantFlag = "DRONE_STAGE_VARIANT"
+	// StageVersionFlag corresponds to plugin.Stage.Version.
+	StageVersionFlag = "DRONE_STAGE_VERSION"
+)
+
+// StageFlags has the cli.Flags for the plugin.Stage
+func StageFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   StageArchFlag,
+			Usage:  "stage arch",
+			EnvVar: plugin.StageArchEnvVar,
+			Hidden: true,
+		},
+		cli.StringSliceFlag{
+			Name:   StageDependsOnFlag,
+			Usage:  "stage depends on",
+			EnvVar: plugin.StageDependsOnEnvVar,
+			Hidden: true,
+		},
+		cli.Int64Flag{
+			Name:   StageFinishedFlag,
+			Usage:  "stage finished",
+			EnvVar: plugin.StageFinishedEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageKindFlag,
+			Usage:  "stage kind",
+			EnvVar: plugin.StageKindEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageMachineFlag,
+			Usage:  "stage machine",
+			EnvVar: plugin.StageMachineEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageNameFlag,
+			Usage:  "stage name",
+			EnvVar: plugin.StageNameEnvVar,
+			Hidden: true,
+		}, cli.IntFlag{
+			Name:   StageNumberFlag,
+			Usage:  "stage number",
+			EnvVar: plugin.StageNumberEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageOSFlag,
+			Usage:  "stage os",
+			EnvVar: plugin.StageOSEnvVar,
+			Hidden: true,
+		}, cli.Int64Flag{
+			Name:   StageStartedFlag,
+			Usage:  "stage started",
+			EnvVar: plugin.StageStartedEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageStatusFlag,
+			Usage:  "stage status",
+			EnvVar: plugin.StageStatusEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageTypeFlag,
+			Usage:  "stage type",
+			EnvVar: plugin.StageTypeEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageVariantFlag,
+			Usage:  "stage variant",
+			EnvVar: plugin.StageVariantEnvVar,
+			Hidden: true,
+		}, cli.StringFlag{
+			Name:   StageVersionFlag,
+			Usage:  "stage version",
+			EnvVar: plugin.StageVersionEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// StageFromContext creates a plugin.Stage from the cli.Context.
+func StageFromContext(ctx *cli.Context) plugin.Stage {
+	return plugin.Stage{
+		Arch:      ctx.String(StageArchFlag),
+		DependsOn: ctx.StringSlice(StageDependsOnFlag),
+		Finished:  time.Unix(ctx.Int64(StageFinishedFlag), 0),
+		Kind:      ctx.String(StageKindFlag),
+		Machine:   ctx.String(StageMachineFlag),
+		Name:      ctx.String(StageNameFlag),
+		Number:    ctx.Int(StageNumberFlag),
+		OS:        ctx.String(StageOSFlag),
+		Started:   time.Unix(ctx.Int64(StageStartedFlag), 0),
+		Status:    ctx.String(StageStatusFlag),
+		Type:      ctx.String(StageTypeFlag),
+		Variant:   ctx.String(StageVariantFlag),
+		Version:   ctx.String(StageVersionFlag),
+	}
+}
 
 //---------------------------------------------------------------------
 // Step Flags
 //---------------------------------------------------------------------
 
 const (
-	// StepNameFlag is the flag name for setting plugin.Step.Name.
+	// StepNameFlag corresponds to plugin.Step.Name.
 	StepNameFlag = "step.name"
-	// StepNumberFlag is the flag name for setting plugin.Step.Number.
+	// StepNumberFlag corresponds to plugin.Step.Number.
 	StepNumberFlag = "step.number"
 )
 
@@ -64,7 +192,7 @@ func StepFlags() []cli.Flag {
 }
 
 // StepFromContext creates a plugin.Step from the cli.Context.
-func StepFromContext(ctx cli.Context) plugin.Step {
+func StepFromContext(ctx *cli.Context) plugin.Step {
 	return plugin.Step{
 		Name:   ctx.String(StepNameFlag),
 		Number: ctx.Int(StepNumberFlag),

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -298,3 +298,94 @@ func StepFromContext(ctx *cli.Context) plugin.Step {
 		Number: ctx.Int(StepNumberFlag),
 	}
 }
+
+//---------------------------------------------------------------------
+// SemVer Flags
+//---------------------------------------------------------------------
+
+const (
+	// SemVerBuildFlag corresponds to SemVer.Build.
+	SemVerBuildFlag = "semver.build"
+	// SemVerErrorFlag corresponds to SemVer.Error.
+	SemVerErrorFlag = "semver.error"
+	// SemVerMajorFlag corresponds to SemVer.Major.
+	SemVerMajorFlag = "semver.major"
+	// SemVerMinorFlag corresponds to SemVer.Minor.
+	SemVerMinorFlag = "semver.minor"
+	// SemVerPatchFlag corresponds to SemVer.Patch.
+	SemVerPatchFlag = "semver.patch"
+	// SemVerPrereleaseFlag corresponds to SemVer.Prerelease
+	SemVerPrereleaseFlag = "semver.prerelease"
+	// SemVerShortFlag corresponds to SemVer.Short.
+	SemVerShortFlag = "semver.short"
+	// SemVerVersionFlag corresponds to SemVer.Version
+	SemVerVersionFlag = "semver.version"
+)
+
+// SemVerFlags has the cli.Flags for the plugin.SemVer.
+func SemVerFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   SemVerBuildFlag,
+			Usage:  "semver build",
+			EnvVar: plugin.SemVerBuildEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerErrorFlag,
+			Usage:  "semver error",
+			EnvVar: plugin.SemVerErrorEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerMajorFlag,
+			Usage:  "semver major",
+			EnvVar: plugin.SemVerMajorEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerMinorFlag,
+			Usage:  "semver minor",
+			EnvVar: plugin.SemVerMinorEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerPatchFlag,
+			Usage:  "semver patch",
+			EnvVar: plugin.SemVerPatchEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerPrereleaseFlag,
+			Usage:  "semver prerelease",
+			EnvVar: plugin.SemVerPrereleaseEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerShortFlag,
+			Usage:  "semver short",
+			EnvVar: plugin.SemVerShortEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   SemVerVersionFlag,
+			Usage:  "semver version",
+			EnvVar: plugin.SemVerVersionEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// SemVerFromContext creates a plugin.Step from the cli.SemVer.
+func SemVerFromContext(ctx *cli.Context) plugin.SemVer {
+	return plugin.SemVer{
+		Build:      ctx.String(SemVerBuildFlag),
+		Error:      ctx.String(SemVerErrorFlag),
+		Major:      ctx.String(SemVerMajorFlag),
+		Minor:      ctx.String(SemVerMinorFlag),
+		Patch:      ctx.String(SemVerPatchFlag),
+		Prerelease: ctx.String(SemVerPrereleaseFlag),
+		Short:      ctx.String(SemVerShortFlag),
+		Version:    ctx.String(SemVerVersionFlag),
+	}
+}

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -195,23 +195,23 @@ func BuildFromContext(ctx *cli.Context) plugin.Build {
 //---------------------------------------------------------------------
 
 const (
-	// RepoDefaultBranchFlag corresponds to Repo.DefaultBranch.
+	// RepoDefaultBranchFlag corresponds to plugin.Repo.DefaultBranch.
 	RepoDefaultBranchFlag = "repo.branch"
-	// RepoFullNameFlag corresponds to Repo.FullName.
+	// RepoFullNameFlag corresponds to plugin.Repo.FullName.
 	RepoFullNameFlag = "repo.full-name"
-	// RepoLinkFlag corresponds to Repo.Link.
+	// RepoLinkFlag corresponds to plugin.Repo.Link.
 	RepoLinkFlag = "repo.link"
-	// RepoNameFlag corresponds to Repo.Name
+	// RepoNameFlag corresponds to plugin.Repo.Name
 	RepoNameFlag = "repo.name"
-	// RepoOwnerFlag corresponds to Repo.Owner.
+	// RepoOwnerFlag corresponds to plugin.Repo.Owner.
 	RepoOwnerFlag = "repo.owner"
-	// RepoPrivateFlag corresponds to Repo.Private.
+	// RepoPrivateFlag corresponds to plugin.Repo.Private.
 	RepoPrivateFlag = "repo.private"
-	// RepoRemoteURLFlag corresponds to Repo.RemoteURL.
+	// RepoRemoteURLFlag corresponds to plugin.Repo.RemoteURL.
 	RepoRemoteURLFlag = "repo.remote-url"
-	// RepoSCMFlag corresponds to Repo.SCM.
+	// RepoSCMFlag corresponds to plugin.Repo.SCM.
 	RepoSCMFlag = "repo.scm"
-	// RepoVisibilityFlag corresponds to Repo.Visbility.
+	// RepoVisibilityFlag corresponds to plugin.Repo.Visbility.
 	RepoVisibilityFlag = "repo.visibility"
 )
 
@@ -576,21 +576,21 @@ func StepFromContext(ctx *cli.Context) plugin.Step {
 //---------------------------------------------------------------------
 
 const (
-	// SemVerBuildFlag corresponds to SemVer.Build.
+	// SemVerBuildFlag corresponds to plugin.SemVer.Build.
 	SemVerBuildFlag = "semver.build"
-	// SemVerErrorFlag corresponds to SemVer.Error.
+	// SemVerErrorFlag corresponds to plugin.SemVer.Error.
 	SemVerErrorFlag = "semver.error"
-	// SemVerMajorFlag corresponds to SemVer.Major.
+	// SemVerMajorFlag corresponds to plugin.SemVer.Major.
 	SemVerMajorFlag = "semver.major"
-	// SemVerMinorFlag corresponds to SemVer.Minor.
+	// SemVerMinorFlag corresponds to plugin.SemVer.Minor.
 	SemVerMinorFlag = "semver.minor"
-	// SemVerPatchFlag corresponds to SemVer.Patch.
+	// SemVerPatchFlag corresponds to plugin.SemVer.Patch.
 	SemVerPatchFlag = "semver.patch"
-	// SemVerPrereleaseFlag corresponds to SemVer.Prerelease
+	// SemVerPrereleaseFlag corresponds to plugin.SemVer.Prerelease
 	SemVerPrereleaseFlag = "semver.prerelease"
-	// SemVerShortFlag corresponds to SemVer.Short.
+	// SemVerShortFlag corresponds to plugin.SemVer.Short.
 	SemVerShortFlag = "semver.short"
-	// SemVerVersionFlag corresponds to SemVer.Version
+	// SemVerVersionFlag corresponds to plugin.SemVer.Version
 	SemVerVersionFlag = "semver.version"
 )
 

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -648,7 +648,7 @@ func SemVerFlags() []cli.Flag {
 	}
 }
 
-// SemVerFromContext creates a plugin.Step from the cli.SemVer.
+// SemVerFromContext creates a plugin.Step from the cli.Context.
 func SemVerFromContext(ctx *cli.Context) plugin.SemVer {
 	return plugin.SemVer{
 		Build:      ctx.String(SemVerBuildFlag),

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -42,31 +42,31 @@ import (
 
 const (
 	// StageArchFlag corresponds to plugin.Stage.Arch.
-	StageArchFlag = "DRONE_STAGE_ARCH"
+	StageArchFlag = "stage.arch"
 	// StageDependsOnFlag corresponds to plugin.Stage.DependsOn.
-	StageDependsOnFlag = "DRONE_STAGE_DEPENDS_ON"
+	StageDependsOnFlag = "stage.depends-on"
 	// StageFinishedFlag corresponds to plugin.Stage.Finished.
-	StageFinishedFlag = "DRONE_STAGE_FINISHED"
+	StageFinishedFlag = "stage.finished"
 	// StageKindFlag corresponds Stage.Kind.
-	StageKindFlag = "DRONE_STAGE_KIND"
+	StageKindFlag = "stage.kind"
 	// StageMachineFlag corresponds to plugin.Stage.Machine.
-	StageMachineFlag = "DRONE_STAGE_MACHINE"
+	StageMachineFlag = "stage.machine"
 	// StageNameFlag corresponds to plugin.Stage.Name.
-	StageNameFlag = "DRONE_STAGE_NAME"
+	StageNameFlag = "stage.name"
 	// StageNumberFlag corresponds to plugin.Stage.Number.
-	StageNumberFlag = "DRONE_STAGE_NUMBER"
+	StageNumberFlag = "stage.number"
 	// StageOSFlag corresponds to plugin.Stage.OS.
-	StageOSFlag = "DRONE_STAGE_OS"
+	StageOSFlag = "stage.os"
 	// StageStartedFlag corresponds to plugin.Stage.Started.
-	StageStartedFlag = "DRONE_STAGE_STARTED"
+	StageStartedFlag = "stage.started"
 	// StageStatusFlag corresponds to plugin.Stage.Status.
-	StageStatusFlag = "DRONE_STAGE_STATUS"
+	StageStatusFlag = "stage.status"
 	// StageTypeFlag corresponds to plugin.Stage.Type.
-	StageTypeFlag = "DRONE_STAGE_TYPE"
+	StageTypeFlag = "stage.type"
 	// StageVariantFlag corresponds to plugin.Stage.Variant.
-	StageVariantFlag = "DRONE_STAGE_VARIANT"
+	StageVariantFlag = "stage.variant"
 	// StageVersionFlag corresponds to plugin.Stage.Version.
-	StageVersionFlag = "DRONE_STAGE_VERSION"
+	StageVersionFlag = "stage.version"
 )
 
 // StageFlags has the cli.Flags for the plugin.Stage

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -37,6 +37,160 @@ import (
 )
 
 //---------------------------------------------------------------------
+// Build Flags
+//---------------------------------------------------------------------
+
+const (
+	// BuildActionFlag corresponds to plugin.Build.Action.
+	BuildActionFlag = "build.action"
+	// BuildCreatedFlag corresponds to plugin.Build.Created.
+	BuildCreatedFlag = "build.created"
+	// BuildDeployToFlag corresponds to plugin.Build.DeployTo.
+	BuildDeployToFlag = "build.deploy-to"
+	// BuildEventFlag corresponds to plugin.Build.Event.
+	BuildEventFlag = "build.event"
+	// BuildFailedStagesFlag corresponds to plugin.Build.FailedStages.
+	BuildFailedStagesFlag = "build.failed-stages"
+	// BuildFailedStepsFlag corresponds to plugin.Build.FailedSteps.
+	BuildFailedStepsFlag = "build.failed-steps"
+	// BuildFinishedFlag corresponds to plugin.Build.Finished.
+	BuildFinishedFlag = "build.finished"
+	// BuildNumberFlag corresponds to plugin.Build.Created.
+	BuildNumberFlag = "build.number"
+	// BuildParentFlag corresponds to plugin.Build.Parent.
+	BuildParentFlag = "build.parent"
+	// BuildPullRequestFlag corresponds to plugin.Build.PullRequest.
+	BuildPullRequestFlag = "build.pull-request"
+	// BuildSourceBranchFlag corresponds to plugin.Build.SourceBranch.
+	BuildSourceBranchFlag = "build.source-branch"
+	// BuildStartedFlag corresponds to plugin.Build.Started.
+	BuildStartedFlag = "build.started"
+	// BuildStatusFlag corresponds to plugin.Build.Status.
+	BuildStatusFlag = "build.status"
+	// BuildTagFlag corresponds to plugin.Build.Tag.
+	BuildTagFlag = "build.tag"
+	// BuildTargetBranchFlag corresponds to plugin.Build.TargetBranch.
+	BuildTargetBranchFlag = "build.target-branch"
+)
+
+// BuildFlags has the cli.Flags for the plugin.Build.
+func BuildFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   BuildActionFlag,
+			Usage:  "build action",
+			EnvVar: plugin.BuildActionEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildCreatedFlag,
+			Usage:  "build created",
+			EnvVar: plugin.BuildCreatedEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildDeployToFlag,
+			Usage:  "build deploy to",
+			EnvVar: plugin.BuildDeployToEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildEventFlag,
+			Usage:  "build event",
+			EnvVar: plugin.BuildEventEnvVar,
+			Hidden: true,
+		},
+		cli.StringSliceFlag{
+			Name:   BuildFailedStagesFlag,
+			Usage:  "build failed stages",
+			EnvVar: plugin.BuildFailedStagesEnvVar,
+			Hidden: true,
+		},
+		cli.StringSliceFlag{
+			Name:   BuildFailedStepsFlag,
+			Usage:  "build failed steps",
+			EnvVar: plugin.BuildFailedStepsEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildFinishedFlag,
+			Usage:  "build finished",
+			EnvVar: plugin.BuildFinishedEnvVar,
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:   BuildNumberFlag,
+			Usage:  "build number",
+			EnvVar: plugin.BuildNumberEnvVar,
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:   BuildParentFlag,
+			Usage:  "build parent",
+			EnvVar: plugin.BuildParentEnvVar,
+			Hidden: true,
+		},
+		cli.IntFlag{
+			Name:   BuildPullRequestFlag,
+			Usage:  "build pull request",
+			EnvVar: plugin.BuildPullRequestEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildSourceBranchFlag,
+			Usage:  "build source branch",
+			EnvVar: plugin.BuildSourceBranchEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildStartedFlag,
+			Usage:  "build started",
+			EnvVar: plugin.BuildStartedEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildStatusFlag,
+			Usage:  "build status",
+			EnvVar: plugin.BuildStatusEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildTagFlag,
+			Usage:  "build tag",
+			EnvVar: plugin.BuildTagEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   BuildTargetBranchFlag,
+			Usage:  "build target branch",
+			EnvVar: plugin.BuildTargetBranchEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// BuildFromContext creates a plugin.Build from the cli.Context.
+func BuildFromContext(ctx *cli.Context) plugin.Build {
+	return plugin.Build{
+		Action:       ctx.String(BuildActionFlag),
+		Created:      time.Unix(ctx.Int64(BuildCreatedFlag), 0),
+		DeployTo:     ctx.String(BuildDeployToFlag),
+		Event:        ctx.String(BuildEventFlag),
+		FailedStages: ctx.StringSlice(BuildFailedStagesFlag),
+		FailedSteps:  ctx.StringSlice(BuildFailedStepsFlag),
+		Finished:     time.Unix(ctx.Int64(BuildFinishedFlag), 0),
+		Number:       ctx.Int(BuildNumberFlag),
+		Parent:       ctx.Int(BuildParentFlag),
+		PullRequest:  ctx.Int(BuildPullRequestFlag),
+		SourceBranch: ctx.String(BuildSourceBranchFlag),
+		Started:      time.Unix(ctx.Int64(BuildStartedFlag), 0),
+		Status:       ctx.String(BuildStatusFlag),
+		Tag:          ctx.String(BuildTagFlag),
+		TargetBranch: ctx.String(BuildTargetBranchFlag),
+	}
+}
+
+//---------------------------------------------------------------------
 // Repo Flags
 //---------------------------------------------------------------------
 

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -37,6 +37,106 @@ import (
 )
 
 //---------------------------------------------------------------------
+// Repo Flags
+//---------------------------------------------------------------------
+
+const (
+	// RepoDefaultBranchFlag corresponds to Repo.DefaultBranch.
+	RepoDefaultBranchFlag = "repo.branch"
+	// RepoFullNameFlag corresponds to Repo.FullName.
+	RepoFullNameFlag = "repo.full-name"
+	// RepoLinkFlag corresponds to Repo.Link.
+	RepoLinkFlag = "repo.link"
+	// RepoNameFlag corresponds to Repo.Name
+	RepoNameFlag = "repo.name"
+	// RepoOwnerFlag corresponds to Repo.Owner.
+	RepoOwnerFlag = "repo.owner"
+	// RepoPrivateFlag corresponds to Repo.Private.
+	RepoPrivateFlag = "repo.private"
+	// RepoRemoteURLFlag corresponds to Repo.RemoteURL.
+	RepoRemoteURLFlag = "repo.remote-url"
+	// RepoSCMFlag corresponds to Repo.SCM.
+	RepoSCMFlag = "repo.scm"
+	// RepoVisibilityFlag corresponds to Repo.Visbility.
+	RepoVisibilityFlag = "repo.visibility"
+)
+
+// RepoFlags has the cli.Flags for the plugin.Repo
+func RepoFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   RepoDefaultBranchFlag,
+			Usage:  "repo default branch",
+			EnvVar: plugin.RepoDefaultBranchEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoFullNameFlag,
+			Usage:  "repo full name",
+			EnvVar: plugin.RepoFullNameEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoLinkFlag,
+			Usage:  "repo link",
+			EnvVar: plugin.RepoLinkEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoNameFlag,
+			Usage:  "repo name",
+			EnvVar: plugin.RepoNameEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoOwnerFlag,
+			Usage:  "repo owner",
+			EnvVar: plugin.RepoOwnerEnvVar,
+			Hidden: true,
+		},
+		cli.BoolFlag{
+			Name:   RepoPrivateFlag,
+			Usage:  "repo private",
+			EnvVar: plugin.RepoPrivateEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoRemoteURLFlag,
+			Usage:  "repo remote url",
+			EnvVar: plugin.RepoRemoteURLEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoSCMFlag,
+			Usage:  "repo scm",
+			EnvVar: plugin.RepoSCMEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   RepoVisibilityFlag,
+			Usage:  "repo visibility",
+			EnvVar: plugin.RepoVisibilityEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// RepoFromContext creates a plugin.Repo from the cli.Context.
+func RepoFromContext(ctx *cli.Context) plugin.Repo {
+	return plugin.Repo{
+		DefaultBranch: ctx.String(RepoDefaultBranchFlag),
+		FullName:      ctx.String(RepoFullNameFlag),
+		Link:          ctx.String(RepoLinkFlag),
+		Name:          ctx.String(RepoNameFlag),
+		Owner:         ctx.String(RepoOwnerFlag),
+		Private:       ctx.Bool(RepoPrivateFlag),
+		RemoteURL:     ctx.String(RepoRemoteURLFlag),
+		SCM:           ctx.String(RepoSCMFlag),
+		Visibility:    ctx.String(RepoVisibilityFlag),
+	}
+}
+
+//---------------------------------------------------------------------
 // Stage Flags
 //---------------------------------------------------------------------
 

--- a/pkg/urfave/urfave.go
+++ b/pkg/urfave/urfave.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2019, the Drone Plugins project authors.
+// Please see the AUTHORS file for details. All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license that can be
+// found in the LICENSE file.
+
+// Package urfave provides helpers for interacting with the `urfave/cli`
+// package when creating plugins for use by the Drone CI/CD service.
+//
+// Drone communicates to plugins by passing in environment variables that have
+// information on the currently executing build. The `urfave/cli` package can
+// read these environment variables and extract them into structs.
+//
+//     import(
+//         "github.com/drone-plugins/drone-plugin-lib/pkg/urfave"
+//         "github.com/urfave/cli"
+//	   )
+//
+//     func main() {
+//         app := cli.New()
+//         app.Name = "my awesome Drone plugin"
+//         app.Run = run
+//         app.Flags = []cli.Flags{
+//             // All my plugin flags
+//         }
+//         app.Flags = append(
+//             app.Flags,
+//             urfave.CommitFlags()...,
+//         )
+//     }
+package urfave
+
+import (
+	"github.com/drone-plugins/drone-plugin-lib/pkg/plugin"
+	"github.com/urfave/cli"
+)
+
+//---------------------------------------------------------------------
+// Step Flags
+//---------------------------------------------------------------------
+
+const (
+	// StepNameFlag is the flag name for setting plugin.Step.Name.
+	StepNameFlag = "step.name"
+	// StepNumberFlag is the flag name for setting plugin.Step.Number.
+	StepNumberFlag = "step.number"
+)
+
+// StepFlags has the cli.Flags for the plugin.Step.
+func StepFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   StepNameFlag,
+			Usage:  "step name",
+			EnvVar: plugin.StepNameEnvVar,
+			Hidden: true,
+		},
+		cli.StringFlag{
+			Name:   StepNumberFlag,
+			Usage:  "step number",
+			EnvVar: plugin.StepNumberEnvVar,
+			Hidden: true,
+		},
+	}
+}
+
+// StepFromContext creates a plugin.Step from the cli.Context.
+func StepFromContext(ctx cli.Context) plugin.Step {
+	return plugin.Step{
+		Name:   ctx.String(StepNameFlag),
+		Number: ctx.Int(StepNumberFlag),
+	}
+}


### PR DESCRIPTION
This came about because while debugging a Drone plugin behind a proxy became this huge mess where I ended up creating a lot of debugging information that would probably be useful in other plugins. I wanted to add the same debugging info to another one of my plugins in here and I started thinking about how cookie cutter all the plugins are in here. So I decided to take a stab at a plugin library that centralized the common code.

Right now this is just around flag parsing into structures. The plugin I was looking to update is slack blame which is definitely missing a lot of information for people to send to a template. So I figured I'd start there with updated structures that fit the info that latest drone passes into a step.

@bradrydzewski has brought up using boilr to generate code and I think that would be another step for this afterwards where there'd be a template that mostly generates everything so all you do is fill out the Exec method and call it a day.