### PR TITLE
Better separation of network, logging and pipeline

### DIFF
--- a/drone/pipeline.go
+++ b/drone/pipeline.go
@@ -9,12 +9,11 @@ package drone
 //
 // Represents the full Drone environment that the plugin is executing in.
 type Pipeline struct {
-	Network Network
-	Build   Build
-	Repo    Repo
-	Commit  Commit
-	Stage   Stage
-	Step    Step
-	SemVer  SemVer
-	System  System
+	Build  Build
+	Repo   Repo
+	Commit Commit
+	Stage  Stage
+	Step   Step
+	SemVer SemVer
+	System System
 }

--- a/urfave/logging.go
+++ b/urfave/logging.go
@@ -21,8 +21,8 @@ func loggingFlags() []cli.Flag {
 	}
 }
 
-// loggingFromContext sets the logrus logging level.
-func loggingFromContext(ctx *cli.Context) {
+// LoggingFromContext sets the logrus logging level.
+func LoggingFromContext(ctx *cli.Context) {
 	lvl, err := logrus.ParseLevel(ctx.String("log-level"))
 
 	if err != nil {

--- a/urfave/network.go
+++ b/urfave/network.go
@@ -29,8 +29,8 @@ func networkFlags() []cli.Flag {
 	}
 }
 
-// networkFromContext creates a drone.Network from the cli.Context.
-func networkFromContext(c *cli.Context) drone.Network {
+// NetworkFromContext creates a drone.Network from the cli.Context.
+func NetworkFromContext(c *cli.Context) drone.Network {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/urfave/urfave.go
+++ b/urfave/urfave.go
@@ -27,18 +27,15 @@ func Flags() []cli.Flag {
 	return flags
 }
 
-// FromContext creates a drone.Pipeline from the cli.Context.
-func FromContext(ctx *cli.Context) drone.Pipeline {
-	loggingFromContext(ctx)
-
+// PipelineFromContext creates a drone.Pipeline from the cli.Context.
+func PipelineFromContext(ctx *cli.Context) drone.Pipeline {
 	return drone.Pipeline{
-		Network: networkFromContext(ctx),
-		Build:   buildFromContext(ctx),
-		Repo:    repoFromContext(ctx),
-		Commit:  commitFromContext(ctx),
-		Stage:   stageFromContext(ctx),
-		Step:    stepFromContext(ctx),
-		SemVer:  semVerFromContext(ctx),
-		System:  systemFromContext(ctx),
+		Build:  buildFromContext(ctx),
+		Repo:   repoFromContext(ctx),
+		Commit: commitFromContext(ctx),
+		Stage:  stageFromContext(ctx),
+		Step:   stepFromContext(ctx),
+		SemVer: semVerFromContext(ctx),
+		System: systemFromContext(ctx),
 	}
 }


### PR DESCRIPTION
I have reverted some last changes to get logging and network extraction
from context separated from the pipeline again as it has been before.
Feels much better to have it separated within the generated plugins.