### PR TITLE
Split Author and Message from Commit

### DIFF
--- a/drone/commit.go
+++ b/drone/commit.go
@@ -5,39 +5,69 @@
 
 package drone
 
-// Commit represents the current commit being built.
-type Commit struct {
-	// SHA for the current commit.
-	SHA string
+type (
+	// Commit represents the current commit being built.
+	Commit struct {
+		// SHA for the current commit.
+		SHA string
 
-	// Before contains the commit sha before the patch is applied.
-	Before string
+		// Before contains the commit sha before the patch is applied.
+		Before string
 
-	// After contains the commit sha after the patch is applied.
-	After string
+		// After contains the commit sha after the patch is applied.
+		After string
 
-	// Ref for the current commit.
-	Ref string
+		// Ref for the current commit.
+		Ref string
 
-	// Branch target for the push or pull request. This may be empty for
-	// tag events.
-	Branch string
+		// Branch target for the push or pull request. This may be empty for
+		// tag events.
+		Branch string
 
-	// Link to the commit or object in the source control management system.
-	Link string
+		// Link to the commit or object in the source control management system.
+		Link string
 
-	// Message for the current commit.
-	Message string
+		// Message for the current commit.
+		Message Message
 
-	// Author of the commit.
-	Author string
+		// Author of the commit.
+		Author Author
 
-	// AuthorName of the commit.
-	AuthorName string
+		// AuthorName of the commit.
+		AuthorName string
 
-	// AuthorEmail of the commit.
-	AuthorEmail string
+		// AuthorEmail of the commit.
+		AuthorEmail string
 
-	// AuthorAvatar of the commit.
-	AuthorAvatar string
+		// AuthorAvatar of the commit.
+		AuthorAvatar string
+	}
+
+	// Author of a Commit.
+	Author struct {
+		// Username of the Commit author.
+		Username string
+		// Name of the Commit author.
+		Name string
+		// Email for the Commit author.
+		Email string
+		// Avatar for the Commit author.
+		Avatar string
+	}
+
+	// Message for a Commit.
+	Message struct {
+		// Title for the Commit.
+		Title string
+		// Body of the Commit message.
+		Body string
+	}
+)
+
+func (a Author) String() string {
+	return a.Username
+}
+
+func (m Message) String() string {
+	return m.Title + m.Body
 }

--- a/urfave/commit.go
+++ b/urfave/commit.go
@@ -6,6 +6,8 @@
 package urfave
 
 import (
+	"strings"
+
 	"github.com/drone-plugins/drone-plugin-lib/drone"
 	"github.com/urfave/cli/v2"
 )
@@ -95,17 +97,24 @@ func commitFlags() []cli.Flag {
 
 // commitFromContext creates a drone.Commit from the cli.Context.
 func commitFromContext(ctx *cli.Context) drone.Commit {
+	splitMsg := strings.Split(ctx.String("commit.message"), "\n")
+
 	return drone.Commit{
-		SHA:          ctx.String("commit.sha"),
-		Before:       ctx.String("commit.before"),
-		After:        ctx.String("commit.after"),
-		Ref:          ctx.String("commit.ref"),
-		Branch:       ctx.String("commit.branch"),
-		Link:         ctx.String("commit.link"),
-		Message:      ctx.String("commit.message"),
-		Author:       ctx.String("commit.author"),
-		AuthorName:   ctx.String("commit.author-name"),
-		AuthorEmail:  ctx.String("commit.author-email"),
-		AuthorAvatar: ctx.String("commit.author-avatar"),
+		SHA:    ctx.String("commit.sha"),
+		Before: ctx.String("commit.before"),
+		After:  ctx.String("commit.after"),
+		Ref:    ctx.String("commit.ref"),
+		Branch: ctx.String("commit.branch"),
+		Link:   ctx.String("commit.link"),
+		Message: drone.Message{
+			Title: strings.TrimSpace(splitMsg[0]),
+			Body:  strings.TrimSpace(strings.Join(splitMsg[1:], "\n")),
+		},
+		Author: drone.Author{
+			Username: ctx.String("commit.author"),
+			Name:     ctx.String("commit.author-name"),
+			Email:    ctx.String("commit.author-email"),
+			Avatar:   ctx.String("commit.author-avatar"),
+		},
 	}
 }


### PR DESCRIPTION
The drone-slack plugin has structs for Author and Message. Since this is the most popular notification plugin it makes sense to follow along with it.