### PR TITLE
Use int64 instead of time.Time

### DIFF
--- a/drone/build.go
+++ b/drone/build.go
@@ -5,10 +5,6 @@
 
 package drone
 
-import (
-	"time"
-)
-
 // Build represents a build of a repository.
 type Build struct {
 	// Branch defines the branch name of the build.
@@ -46,13 +42,13 @@ type Build struct {
 	Link string
 
 	// Created time of the build.
-	Created time.Time
+	Created int64
 
 	// Started time of the build.
-	Started time.Time
+	Started int64
 
 	// Finished time of the build.
-	Finished time.Time
+	Finished int64
 
 	// DeployTo the environment.
 	DeployTo string

--- a/drone/stage.go
+++ b/drone/stage.go
@@ -5,8 +5,6 @@
 
 package drone
 
-import "time"
-
 // Stage represents a build stage.
 type Stage struct {
 	// Kind is the kind of resource being executed.
@@ -49,13 +47,13 @@ type Stage struct {
 
 	// Started is the unix timestamp for when a build stage was started by
 	// the runner.
-	Started time.Time
+	Started int64
 
 	// Finished is the unix timestamp for when the pipeline is finished.
 	//
 	// A running pipleine cannot have a finish timestamp, therefore, the
 	// system aways sets this value to the current timestamp.
-	Finished time.Time
+	Finished int64
 
 	// DependsOn is a list of dependencies for the current build stage.
 	DependsOn []string

--- a/urfave/build.go
+++ b/urfave/build.go
@@ -6,8 +6,6 @@
 package urfave
 
 import (
-	"time"
-
 	"github.com/drone-plugins/drone-plugin-lib/drone"
 	"github.com/urfave/cli/v2"
 )
@@ -122,9 +120,9 @@ func buildFromContext(ctx *cli.Context) drone.Build {
 		Action:       ctx.String("build.action"),
 		Status:       ctx.String("build.status"),
 		Link:         ctx.String("build.link"),
-		Created:      time.Unix(ctx.Int64("build.created"), 0),
-		Started:      time.Unix(ctx.Int64("build.started"), 0),
-		Finished:     time.Unix(ctx.Int64("build.finished"), 0),
+		Created:      ctx.Int64("build.created"),
+		Started:      ctx.Int64("build.started"),
+		Finished:     ctx.Int64("build.finished"),
 		DeployTo:     ctx.String("build.deploy-to"),
 		DeployID:     ctx.Int("build.deploy-id"),
 		FailedStages: ctx.StringSlice("build.failed-stages"),

--- a/urfave/stage.go
+++ b/urfave/stage.go
@@ -6,8 +6,6 @@
 package urfave
 
 import (
-	"time"
-
 	"github.com/drone-plugins/drone-plugin-lib/drone"
 	"github.com/urfave/cli/v2"
 )
@@ -122,8 +120,8 @@ func stageFromContext(ctx *cli.Context) drone.Stage {
 		Variant:   ctx.String("stage.variant"),
 		Version:   ctx.String("stage.version"),
 		Status:    ctx.String("stage.status"),
-		Started:   time.Unix(ctx.Int64("stage.started"), 0),
-		Finished:  time.Unix(ctx.Int64("stage.finished"), 0),
+		Started:   ctx.Int64("stage.started"),
+		Finished:  ctx.Int64("stage.finished"),
 		DependsOn: ctx.StringSlice("stage.depends-on"),
 	}
 }


### PR DESCRIPTION
The `drone-template-lib` wants `int64` for a number of its helpers. Using `time.Time` caused a number of crashes when `drone-slack` was upgraded.